### PR TITLE
複数パターンのクソコラが作れる仕組みを追加

### DIFF
--- a/app/Http/Controllers/ImageController.php
+++ b/app/Http/Controllers/ImageController.php
@@ -75,7 +75,7 @@ class ImageController extends Controller
             \Log::debug('画像が指定されていません');
         }
 
-        return redirect("/image/{$image->id}");
+        return redirect("/image/{$image->id}/kusocolas/1");
     }
 
     /**
@@ -84,9 +84,14 @@ class ImageController extends Controller
      * @param  Image $image
      * @return \Illuminate\Http\Response
      */
-    public function show(Image $image)
+    public function show(Image $image, $kusocola)
     {
-        return view('image', ['image' => $image]);
+        return view('image', 
+            [
+                'image' => $image,
+                'kusocola' => $kusocola
+            ]
+        );
     }
 
     /**

--- a/resources/views/image.blade.php
+++ b/resources/views/image.blade.php
@@ -12,39 +12,7 @@
 @endsection
 
 @section('content')
-    <div class="kusocolla">
-        <img class="kusocolla__img-fixed" src="/images/kusocolla01/kusocolla01-01.jpg" alt="">
-        <div class="kusocolla__face face-01">
-            @for($i =0; $i<$image->face_num; $i++)
-                <img src="{{url("/")}}/storage/image/{{$image->getFolder()}}/{{$i}}.{{$image->getExtension()}}" alt="image" style="max-width:100%">
-            @endfor
-        </div>
-        <div class="kusocolla__face face-02">
-            @for($i =0; $i<$image->face_num; $i++)
-                <img src="{{url("/")}}/storage/image/{{$image->getFolder()}}/{{$i}}.{{$image->getExtension()}}" alt="image" style="max-width:100%">
-            @endfor
-        </div>
-        <div class="kusocolla__face face-03">
-            @for($i =0; $i<$image->face_num; $i++)
-                <img src="{{url("/")}}/storage/image/{{$image->getFolder()}}/{{$i}}.{{$image->getExtension()}}" alt="image" style="max-width:100%">
-            @endfor
-        </div>
-        <div class="kusocolla__face face-05 move02">
-            @for($i =0; $i<$image->face_num; $i++)
-                <img src="{{url("/")}}/storage/image/{{$image->getFolder()}}/{{$i}}.{{$image->getExtension()}}" alt="image" style="max-width:100%">
-            @endfor
-        </div>
-        <div class="kusocolla__img-move move01">
-            <div class="kusocolla__img__inner">
-                <div class="kusocolla__face face-04">
-                    @for($i =0; $i<$image->face_num; $i++)
-                        <img src="{{url("/")}}/storage/image/{{$image->getFolder()}}/{{$i}}.{{$image->getExtension()}}" alt="image" style="max-width:100%">
-                    @endfor
-                </div>
-                <img class="kusocolla__img-fixed" src="/images/kusocolla01/kusocolla01-02.png" alt="">
-            </div>
-        </div>
-    </div>
+@include('kusocolas.' . $kusocola)
     <div class="container">
         <div class="row justify-content-center">
             <!-- TODO: #15: ちゃんとレスポンシブ対応する -->

--- a/resources/views/kusocolas/1.blade.php
+++ b/resources/views/kusocolas/1.blade.php
@@ -1,0 +1,33 @@
+    <div class="kusocolla">
+        <img class="kusocolla__img-fixed" src="/images/kusocolla01/kusocolla01-01.jpg" alt="">
+        <div class="kusocolla__face face-01">
+            @for($i =0; $i<$image->face_num; $i++)
+                <img src="{{url("/")}}/storage/image/{{$image->getFolder()}}/{{$i}}.{{$image->getExtension()}}" alt="image" style="max-width:100%">
+            @endfor
+        </div>
+        <div class="kusocolla__face face-02">
+            @for($i =0; $i<$image->face_num; $i++)
+                <img src="{{url("/")}}/storage/image/{{$image->getFolder()}}/{{$i}}.{{$image->getExtension()}}" alt="image" style="max-width:100%">
+            @endfor
+        </div>
+        <div class="kusocolla__face face-03">
+            @for($i =0; $i<$image->face_num; $i++)
+                <img src="{{url("/")}}/storage/image/{{$image->getFolder()}}/{{$i}}.{{$image->getExtension()}}" alt="image" style="max-width:100%">
+            @endfor
+        </div>
+        <div class="kusocolla__face face-05 move02">
+            @for($i =0; $i<$image->face_num; $i++)
+                <img src="{{url("/")}}/storage/image/{{$image->getFolder()}}/{{$i}}.{{$image->getExtension()}}" alt="image" style="max-width:100%">
+            @endfor
+        </div>
+        <div class="kusocolla__img-move move01">
+            <div class="kusocolla__img__inner">
+                <div class="kusocolla__face face-04">
+                    @for($i =0; $i<$image->face_num; $i++)
+                        <img src="{{url("/")}}/storage/image/{{$image->getFolder()}}/{{$i}}.{{$image->getExtension()}}" alt="image" style="max-width:100%">
+                    @endfor
+                </div>
+                <img class="kusocolla__img-fixed" src="/images/kusocolla01/kusocolla01-02.png" alt="">
+            </div>
+        </div>
+    </div>

--- a/resources/views/kusocolas/2.blade.php
+++ b/resources/views/kusocolas/2.blade.php
@@ -1,0 +1,13 @@
+    <div class="kusocolla">
+        <img class="kusocolla__img-fixed" src="/images/kusocolla01/kusocolla01-01.jpg" alt="">
+        <div class="kusocolla__img-move move01">
+            <div class="kusocolla__img__inner">
+                <div class="kusocolla__face face-04">
+                    @for($i =0; $i<$image->face_num; $i++)
+                        <img src="{{url("/")}}/storage/image/{{$image->getFolder()}}/{{$i}}.{{$image->getExtension()}}" alt="image" style="max-width:100%">
+                    @endfor
+                </div>
+                <img class="kusocolla__img-fixed" src="/images/kusocolla01/kusocolla01-02.png" alt="">
+            </div>
+        </div>
+    </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -15,4 +15,7 @@ Route::get('/', function () {
     return view('welcome');
 });
 
-Route::resource('image', 'ImageController');
+// Route::resource('image', 'ImageController');
+
+Route::post('image', 'ImageController@store');
+Route::get('image/{image}/kusocolas/{kusocola}', 'ImageController@show');

--- a/routes/web.php
+++ b/routes/web.php
@@ -15,7 +15,5 @@ Route::get('/', function () {
     return view('welcome');
 });
 
-// Route::resource('image', 'ImageController');
-
 Route::post('image', 'ImageController@store');
 Route::get('image/{image}/kusocolas/{kusocola}', 'ImageController@show');


### PR DESCRIPTION
# 概要
複数パターンのクソコラが作れる仕組みを追加

# 対応内容
- クソコラパターン2を仮で追加
- 普通に使った場合は、今まで通りのクソコラが出る
- リダイレクト先を変更。末尾にKusocolas/{クソコラのID}がついた）
例：`https://dev1.kusocolla-maker.gokigen-ch.com/image/55/kusocolas/1`
- 最後の数字を2に変えると、違うパターンのクソコラが出る（今までの劣化版）
例：`https://dev1.kusocolla-maker.gokigen-ch.com/image/55/kusocolas/2`

# 想定する修正
- views/kusocolas/2.blade.phpをちゃんとした新しいクソコラに作り変える
- もっと足したい場合は、3.blade.phpを作って、URLの末尾を3にすればそれが表示されるはず。
- 4以降も同様。
- 末尾は数字じゃなくて文字列でもできるかも。

# 保留
以下はとりあえず保留とする。多分、そんなに大変じゃなくできる。
- クソコラをランダムで出す機能
  - 想定する実装
ImageController.phpのstoreメソッドで、views/kusocolas/以下にあるファイルリストを取得して、ランダム表示する、みたいな感じを想定
