### PR TITLE
fix: クソコラ画面に遷移した時最初画面がちらつく

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -12124,18 +12124,18 @@ label > input {
 .kusocolla .move01 {
   top: 0;
   left: 0;
-  -webkit-animation: move01 2s 1;
-          animation: move01 2s 1;
+  -webkit-animation: move01-01 2s 1;
+          animation: move01-01 2s 1;
 }
 
 .kusocolla .move02 {
   width: 240px;
   height: 240px;
-  -webkit-animation: move02 5s 1;
-          animation: move02 5s 1;
+  -webkit-animation: move01-02 5s 1;
+          animation: move01-02 5s 1;
 }
 
-@-webkit-keyframes move01 {
+@-webkit-keyframes move01-01 {
   0% {
     top: 220px;
     left: 200px;
@@ -12157,7 +12157,7 @@ label > input {
   }
 }
 
-@keyframes move01 {
+@keyframes move01-01 {
   0% {
     top: 220px;
     left: 200px;
@@ -12179,7 +12179,7 @@ label > input {
   }
 }
 
-@-webkit-keyframes move02 {
+@-webkit-keyframes move01-02 {
   0% {
     -webkit-transform: rotate(0deg);
     transform: rotate(0deg);
@@ -12200,7 +12200,7 @@ label > input {
   }
 }
 
-@keyframes move02 {
+@keyframes move01-02 {
   0% {
     -webkit-transform: rotate(0deg);
     transform: rotate(0deg);
@@ -12228,8 +12228,8 @@ label > input {
   background: url(/images/kusocolla02/kusocolla02-01.jpg) no-repeat top;
   background-size: 100%;
   overflow: hidden;
-  -webkit-animation: move01 4s infinite step-end;
-          animation: move01 4s infinite step-end;
+  -webkit-animation: move02-01 4s infinite step-end;
+          animation: move02-01 4s infinite step-end;
 }
 
 .kusocolla02 .kusocolla02__img-fixed {
@@ -12284,8 +12284,8 @@ label > input {
   width: 12%;
   height: auto;
   opacity: 1;
-  -webkit-animation: face01 4s infinite step-end;
-          animation: face01 4s infinite step-end;
+  -webkit-animation: face02-01 4s infinite step-end;
+          animation: face02-01 4s infinite step-end;
 }
 
 .kusocolla02 .face-02 {
@@ -12294,8 +12294,8 @@ label > input {
   width: 12%;
   height: auto;
   opacity: 1;
-  -webkit-animation: face02 4s infinite step-end;
-          animation: face02 4s infinite step-end;
+  -webkit-animation: face02-02 4s infinite step-end;
+          animation: face02-02 4s infinite step-end;
 }
 
 .kusocolla02 .face-03 {
@@ -12304,8 +12304,8 @@ label > input {
   width: 12%;
   height: auto;
   opacity: 1;
-  -webkit-animation: face03 4s infinite step-end;
-          animation: face03 4s infinite step-end;
+  -webkit-animation: face02-03 4s infinite step-end;
+          animation: face02-03 4s infinite step-end;
 }
 
 .kusocolla02 .face-04 {
@@ -12314,8 +12314,8 @@ label > input {
   width: 12%;
   height: auto;
   opacity: 1;
-  -webkit-animation: face04 4s infinite step-end;
-          animation: face04 4s infinite step-end;
+  -webkit-animation: face02-04 4s infinite step-end;
+          animation: face02-04 4s infinite step-end;
 }
 
 @-webkit-keyframes heart {
@@ -12430,7 +12430,7 @@ label > input {
   }
 }
 
-@keyframes move01 {
+@-webkit-keyframes move02-01 {
   0% {
     background: url(/images/kusocolla02/kusocolla02-01.jpg) no-repeat top;
     background-size: 100%;
@@ -12477,7 +12477,54 @@ label > input {
   }
 }
 
-@-webkit-keyframes face01 {
+@keyframes move02-01 {
+  0% {
+    background: url(/images/kusocolla02/kusocolla02-01.jpg) no-repeat top;
+    background-size: 100%;
+  }
+
+  12% {
+    background: url(/images/kusocolla02/kusocolla02-02.jpg) no-repeat top;
+    background-size: 100%;
+  }
+
+  25% {
+    background: url(/images/kusocolla02/kusocolla02-03.jpg) no-repeat top;
+    background-size: 100%;
+  }
+
+  37% {
+    background: url(/images/kusocolla02/kusocolla02-04.jpg) no-repeat top;
+    background-size: 100%;
+  }
+
+  50% {
+    background: url(/images/kusocolla02/kusocolla02-05.jpg) no-repeat top;
+    background-size: 100%;
+  }
+
+  62% {
+    background: url(/images/kusocolla02/kusocolla02-06.jpg) no-repeat top;
+    background-size: 100%;
+  }
+
+  75% {
+    background: url(/images/kusocolla02/kusocolla02-07.jpg) no-repeat top;
+    background-size: 100%;
+  }
+
+  87% {
+    background: url(/images/kusocolla02/kusocolla02-08.jpg) no-repeat top;
+    background-size: 100%;
+  }
+
+  100% {
+    background: url(/images/kusocolla02/kusocolla02-01.jpg) no-repeat top;
+    background-size: 100%;
+  }
+}
+
+@-webkit-keyframes face02-01 {
   0% {
     opacity: 0;
   }
@@ -12519,7 +12566,7 @@ label > input {
   }
 }
 
-@keyframes face01 {
+@keyframes face02-01 {
   0% {
     opacity: 0;
   }
@@ -12561,7 +12608,7 @@ label > input {
   }
 }
 
-@-webkit-keyframes face02 {
+@-webkit-keyframes face02-02 {
   0% {
     opacity: 0;
   }
@@ -12603,7 +12650,7 @@ label > input {
   }
 }
 
-@keyframes face02 {
+@keyframes face02-02 {
   0% {
     opacity: 0;
   }
@@ -12645,51 +12692,7 @@ label > input {
   }
 }
 
-@-webkit-keyframes face03 {
-  0% {
-    top: 6%;
-    left: 65%;
-    opacity: 1;
-  }
-
-  12% {
-    opacity: 0;
-  }
-
-  25% {
-    opacity: 0;
-  }
-
-  37% {
-    opacity: 0;
-  }
-
-  50% {
-    opacity: 0;
-  }
-
-  62% {
-    opacity: 0;
-  }
-
-  75% {
-    top: 6%;
-    left: 65%;
-    opacity: 1;
-  }
-
-  87% {
-    opacity: 0;
-  }
-
-  100% {
-    top: 6%;
-    left: 65%;
-    opacity: 1;
-  }
-}
-
-@keyframes face03 {
+@-webkit-keyframes face02-03 {
   0% {
     top: 6%;
     left: 65%;
@@ -12733,7 +12736,51 @@ label > input {
   }
 }
 
-@-webkit-keyframes face04 {
+@keyframes face02-03 {
+  0% {
+    top: 6%;
+    left: 65%;
+    opacity: 1;
+  }
+
+  12% {
+    opacity: 0;
+  }
+
+  25% {
+    opacity: 0;
+  }
+
+  37% {
+    opacity: 0;
+  }
+
+  50% {
+    opacity: 0;
+  }
+
+  62% {
+    opacity: 0;
+  }
+
+  75% {
+    top: 6%;
+    left: 65%;
+    opacity: 1;
+  }
+
+  87% {
+    opacity: 0;
+  }
+
+  100% {
+    top: 6%;
+    left: 65%;
+    opacity: 1;
+  }
+}
+
+@-webkit-keyframes face02-04 {
   0% {
     opacity: 0;
   }
@@ -12775,7 +12822,7 @@ label > input {
   }
 }
 
-@keyframes face04 {
+@keyframes face02-04 {
   0% {
     opacity: 0;
   }

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -110,7 +110,6 @@ module.exports = __webpack_require__(/*! ./lib/axios */ "./node_modules/axios/li
 var utils = __webpack_require__(/*! ./../utils */ "./node_modules/axios/lib/utils.js");
 var settle = __webpack_require__(/*! ./../core/settle */ "./node_modules/axios/lib/core/settle.js");
 var buildURL = __webpack_require__(/*! ./../helpers/buildURL */ "./node_modules/axios/lib/helpers/buildURL.js");
-var buildFullPath = __webpack_require__(/*! ../core/buildFullPath */ "./node_modules/axios/lib/core/buildFullPath.js");
 var parseHeaders = __webpack_require__(/*! ./../helpers/parseHeaders */ "./node_modules/axios/lib/helpers/parseHeaders.js");
 var isURLSameOrigin = __webpack_require__(/*! ./../helpers/isURLSameOrigin */ "./node_modules/axios/lib/helpers/isURLSameOrigin.js");
 var createError = __webpack_require__(/*! ../core/createError */ "./node_modules/axios/lib/core/createError.js");
@@ -133,8 +132,7 @@ module.exports = function xhrAdapter(config) {
       requestHeaders.Authorization = 'Basic ' + btoa(username + ':' + password);
     }
 
-    var fullPath = buildFullPath(config.baseURL, config.url);
-    request.open(config.method.toUpperCase(), buildURL(fullPath, config.params, config.paramsSerializer), true);
+    request.open(config.method.toUpperCase(), buildURL(config.url, config.params, config.paramsSerializer), true);
 
     // Set the request timeout in MS
     request.timeout = config.timeout;
@@ -195,11 +193,7 @@ module.exports = function xhrAdapter(config) {
 
     // Handle timeout
     request.ontimeout = function handleTimeout() {
-      var timeoutErrorMessage = 'timeout of ' + config.timeout + 'ms exceeded';
-      if (config.timeoutErrorMessage) {
-        timeoutErrorMessage = config.timeoutErrorMessage;
-      }
-      reject(createError(timeoutErrorMessage, config, 'ECONNABORTED',
+      reject(createError('timeout of ' + config.timeout + 'ms exceeded', config, 'ECONNABORTED',
         request));
 
       // Clean up request
@@ -213,7 +207,7 @@ module.exports = function xhrAdapter(config) {
       var cookies = __webpack_require__(/*! ./../helpers/cookies */ "./node_modules/axios/lib/helpers/cookies.js");
 
       // Add xsrf header
-      var xsrfValue = (config.withCredentials || isURLSameOrigin(fullPath)) && config.xsrfCookieName ?
+      var xsrfValue = (config.withCredentials || isURLSameOrigin(config.url)) && config.xsrfCookieName ?
         cookies.read(config.xsrfCookieName) :
         undefined;
 
@@ -236,8 +230,8 @@ module.exports = function xhrAdapter(config) {
     }
 
     // Add withCredentials to request if needed
-    if (!utils.isUndefined(config.withCredentials)) {
-      request.withCredentials = !!config.withCredentials;
+    if (config.withCredentials) {
+      request.withCredentials = true;
     }
 
     // Add responseType to request if needed
@@ -516,15 +510,7 @@ Axios.prototype.request = function request(config) {
   }
 
   config = mergeConfig(this.defaults, config);
-
-  // Set config.method
-  if (config.method) {
-    config.method = config.method.toLowerCase();
-  } else if (this.defaults.method) {
-    config.method = this.defaults.method.toLowerCase();
-  } else {
-    config.method = 'get';
-  }
+  config.method = config.method ? config.method.toLowerCase() : 'get';
 
   // Hook up interceptors middleware
   var chain = [dispatchRequest, undefined];
@@ -641,38 +627,6 @@ module.exports = InterceptorManager;
 
 /***/ }),
 
-/***/ "./node_modules/axios/lib/core/buildFullPath.js":
-/*!******************************************************!*\
-  !*** ./node_modules/axios/lib/core/buildFullPath.js ***!
-  \******************************************************/
-/*! no static exports found */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-
-
-var isAbsoluteURL = __webpack_require__(/*! ../helpers/isAbsoluteURL */ "./node_modules/axios/lib/helpers/isAbsoluteURL.js");
-var combineURLs = __webpack_require__(/*! ../helpers/combineURLs */ "./node_modules/axios/lib/helpers/combineURLs.js");
-
-/**
- * Creates a new URL by combining the baseURL with the requestedURL,
- * only when the requestedURL is not already an absolute URL.
- * If the requestURL is absolute, this function returns the requestedURL untouched.
- *
- * @param {string} baseURL The base URL
- * @param {string} requestedURL Absolute or relative URL to combine
- * @returns {string} The combined full path
- */
-module.exports = function buildFullPath(baseURL, requestedURL) {
-  if (baseURL && !isAbsoluteURL(requestedURL)) {
-    return combineURLs(baseURL, requestedURL);
-  }
-  return requestedURL;
-};
-
-
-/***/ }),
-
 /***/ "./node_modules/axios/lib/core/createError.js":
 /*!****************************************************!*\
   !*** ./node_modules/axios/lib/core/createError.js ***!
@@ -717,6 +671,8 @@ var utils = __webpack_require__(/*! ./../utils */ "./node_modules/axios/lib/util
 var transformData = __webpack_require__(/*! ./transformData */ "./node_modules/axios/lib/core/transformData.js");
 var isCancel = __webpack_require__(/*! ../cancel/isCancel */ "./node_modules/axios/lib/cancel/isCancel.js");
 var defaults = __webpack_require__(/*! ../defaults */ "./node_modules/axios/lib/defaults.js");
+var isAbsoluteURL = __webpack_require__(/*! ./../helpers/isAbsoluteURL */ "./node_modules/axios/lib/helpers/isAbsoluteURL.js");
+var combineURLs = __webpack_require__(/*! ./../helpers/combineURLs */ "./node_modules/axios/lib/helpers/combineURLs.js");
 
 /**
  * Throws a `Cancel` if cancellation has been requested.
@@ -736,6 +692,11 @@ function throwIfCancellationRequested(config) {
 module.exports = function dispatchRequest(config) {
   throwIfCancellationRequested(config);
 
+  // Support baseURL config
+  if (config.baseURL && !isAbsoluteURL(config.url)) {
+    config.url = combineURLs(config.baseURL, config.url);
+  }
+
   // Ensure headers exist
   config.headers = config.headers || {};
 
@@ -750,7 +711,7 @@ module.exports = function dispatchRequest(config) {
   config.headers = utils.merge(
     config.headers.common || {},
     config.headers[config.method] || {},
-    config.headers
+    config.headers || {}
   );
 
   utils.forEach(
@@ -873,23 +834,13 @@ module.exports = function mergeConfig(config1, config2) {
   config2 = config2 || {};
   var config = {};
 
-  var valueFromConfig2Keys = ['url', 'method', 'params', 'data'];
-  var mergeDeepPropertiesKeys = ['headers', 'auth', 'proxy'];
-  var defaultToConfig2Keys = [
-    'baseURL', 'url', 'transformRequest', 'transformResponse', 'paramsSerializer',
-    'timeout', 'withCredentials', 'adapter', 'responseType', 'xsrfCookieName',
-    'xsrfHeaderName', 'onUploadProgress', 'onDownloadProgress',
-    'maxContentLength', 'validateStatus', 'maxRedirects', 'httpAgent',
-    'httpsAgent', 'cancelToken', 'socketPath'
-  ];
-
-  utils.forEach(valueFromConfig2Keys, function valueFromConfig2(prop) {
+  utils.forEach(['url', 'method', 'params', 'data'], function valueFromConfig2(prop) {
     if (typeof config2[prop] !== 'undefined') {
       config[prop] = config2[prop];
     }
   });
 
-  utils.forEach(mergeDeepPropertiesKeys, function mergeDeepProperties(prop) {
+  utils.forEach(['headers', 'auth', 'proxy'], function mergeDeepProperties(prop) {
     if (utils.isObject(config2[prop])) {
       config[prop] = utils.deepMerge(config1[prop], config2[prop]);
     } else if (typeof config2[prop] !== 'undefined') {
@@ -901,25 +852,13 @@ module.exports = function mergeConfig(config1, config2) {
     }
   });
 
-  utils.forEach(defaultToConfig2Keys, function defaultToConfig2(prop) {
-    if (typeof config2[prop] !== 'undefined') {
-      config[prop] = config2[prop];
-    } else if (typeof config1[prop] !== 'undefined') {
-      config[prop] = config1[prop];
-    }
-  });
-
-  var axiosKeys = valueFromConfig2Keys
-    .concat(mergeDeepPropertiesKeys)
-    .concat(defaultToConfig2Keys);
-
-  var otherKeys = Object
-    .keys(config2)
-    .filter(function filterAxiosKeys(key) {
-      return axiosKeys.indexOf(key) === -1;
-    });
-
-  utils.forEach(otherKeys, function otherKeysDefaultToConfig2(prop) {
+  utils.forEach([
+    'baseURL', 'transformRequest', 'transformResponse', 'paramsSerializer',
+    'timeout', 'withCredentials', 'adapter', 'responseType', 'xsrfCookieName',
+    'xsrfHeaderName', 'onUploadProgress', 'onDownloadProgress', 'maxContentLength',
+    'validateStatus', 'maxRedirects', 'httpAgent', 'httpsAgent', 'cancelToken',
+    'socketPath'
+  ], function defaultToConfig2(prop) {
     if (typeof config2[prop] !== 'undefined') {
       config[prop] = config2[prop];
     } else if (typeof config1[prop] !== 'undefined') {
@@ -1027,12 +966,13 @@ function setContentTypeIfUnset(headers, value) {
 
 function getDefaultAdapter() {
   var adapter;
-  if (typeof XMLHttpRequest !== 'undefined') {
-    // For browsers use XHR adapter
-    adapter = __webpack_require__(/*! ./adapters/xhr */ "./node_modules/axios/lib/adapters/xhr.js");
-  } else if (typeof process !== 'undefined' && Object.prototype.toString.call(process) === '[object process]') {
+  // Only Node.JS has a process variable that is of [[Class]] process
+  if (typeof process !== 'undefined' && Object.prototype.toString.call(process) === '[object process]') {
     // For node use HTTP adapter
     adapter = __webpack_require__(/*! ./adapters/http */ "./node_modules/axios/lib/adapters/xhr.js");
+  } else if (typeof XMLHttpRequest !== 'undefined') {
+    // For browsers use XHR adapter
+    adapter = __webpack_require__(/*! ./adapters/xhr */ "./node_modules/axios/lib/adapters/xhr.js");
   }
   return adapter;
 }
@@ -1554,6 +1494,7 @@ module.exports = function spread(callback) {
 
 
 var bind = __webpack_require__(/*! ./helpers/bind */ "./node_modules/axios/lib/helpers/bind.js");
+var isBuffer = __webpack_require__(/*! is-buffer */ "./node_modules/is-buffer/index.js");
 
 /*global toString:true*/
 
@@ -1569,27 +1510,6 @@ var toString = Object.prototype.toString;
  */
 function isArray(val) {
   return toString.call(val) === '[object Array]';
-}
-
-/**
- * Determine if a value is undefined
- *
- * @param {Object} val The value to test
- * @returns {boolean} True if the value is undefined, otherwise false
- */
-function isUndefined(val) {
-  return typeof val === 'undefined';
-}
-
-/**
- * Determine if a value is a Buffer
- *
- * @param {Object} val The value to test
- * @returns {boolean} True if value is a Buffer, otherwise false
- */
-function isBuffer(val) {
-  return val !== null && !isUndefined(val) && val.constructor !== null && !isUndefined(val.constructor)
-    && typeof val.constructor.isBuffer === 'function' && val.constructor.isBuffer(val);
 }
 
 /**
@@ -1646,6 +1566,16 @@ function isString(val) {
  */
 function isNumber(val) {
   return typeof val === 'number';
+}
+
+/**
+ * Determine if a value is undefined
+ *
+ * @param {Object} val The value to test
+ * @returns {boolean} True if the value is undefined, otherwise false
+ */
+function isUndefined(val) {
+  return typeof val === 'undefined';
 }
 
 /**
@@ -6426,6 +6356,28 @@ module.exports = {
 
 })));
 //# sourceMappingURL=bootstrap.js.map
+
+
+/***/ }),
+
+/***/ "./node_modules/is-buffer/index.js":
+/*!*****************************************!*\
+  !*** ./node_modules/is-buffer/index.js ***!
+  \*****************************************/
+/*! no static exports found */
+/***/ (function(module, exports) {
+
+/*!
+ * Determine if an object is a Buffer
+ *
+ * @author   Feross Aboukhadijeh <https://feross.org>
+ * @license  MIT
+ */
+
+module.exports = function isBuffer (obj) {
+  return obj != null && obj.constructor != null &&
+    typeof obj.constructor.isBuffer === 'function' && obj.constructor.isBuffer(obj)
+}
 
 
 /***/ }),
@@ -34167,7 +34119,7 @@ return jQuery;
 __webpack_require__.r(__webpack_exports__);
 /* WEBPACK VAR INJECTION */(function(global) {/**!
  * @fileOverview Kickass library to create and place poppers near their reference elements.
- * @version 1.16.1
+ * @version 1.16.0
  * @license
  * Copyright (c) 2016 Federico Zivolo and contributors
  *
@@ -34513,7 +34465,7 @@ function getBordersSize(styles, axis) {
   var sideA = axis === 'x' ? 'Left' : 'Top';
   var sideB = sideA === 'Left' ? 'Right' : 'Bottom';
 
-  return parseFloat(styles['border' + sideA + 'Width']) + parseFloat(styles['border' + sideB + 'Width']);
+  return parseFloat(styles['border' + sideA + 'Width'], 10) + parseFloat(styles['border' + sideB + 'Width'], 10);
 }
 
 function getSize(axis, body, html, computedStyle) {
@@ -34668,8 +34620,8 @@ function getOffsetRectRelativeToArbitraryNode(children, parent) {
   var scrollParent = getScrollParent(children);
 
   var styles = getStyleComputedProperty(parent);
-  var borderTopWidth = parseFloat(styles.borderTopWidth);
-  var borderLeftWidth = parseFloat(styles.borderLeftWidth);
+  var borderTopWidth = parseFloat(styles.borderTopWidth, 10);
+  var borderLeftWidth = parseFloat(styles.borderLeftWidth, 10);
 
   // In cases where the parent is fixed, we must ignore negative scroll in offset calc
   if (fixedPosition && isHTML) {
@@ -34690,8 +34642,8 @@ function getOffsetRectRelativeToArbitraryNode(children, parent) {
   // differently when margins are applied to it. The margins are included in
   // the box of the documentElement, in the other cases not.
   if (!isIE10 && isHTML) {
-    var marginTop = parseFloat(styles.marginTop);
-    var marginLeft = parseFloat(styles.marginLeft);
+    var marginTop = parseFloat(styles.marginTop, 10);
+    var marginLeft = parseFloat(styles.marginLeft, 10);
 
     offsets.top -= borderTopWidth - marginTop;
     offsets.bottom -= borderTopWidth - marginTop;
@@ -35630,8 +35582,8 @@ function arrow(data, options) {
   // Compute the sideValue using the updated popper offsets
   // take popper margin in account because we don't have this info available
   var css = getStyleComputedProperty(data.instance.popper);
-  var popperMarginSide = parseFloat(css['margin' + sideCapitalized]);
-  var popperBorderSide = parseFloat(css['border' + sideCapitalized + 'Width']);
+  var popperMarginSide = parseFloat(css['margin' + sideCapitalized], 10);
+  var popperBorderSide = parseFloat(css['border' + sideCapitalized + 'Width'], 10);
   var sideValue = center - data.offsets.popper[side] - popperMarginSide - popperBorderSide;
 
   // prevent arrowElement from being placed not contiguously to its popper
@@ -37188,8 +37140,8 @@ function validFileType(file) {
 /*! no static exports found */
 /***/ (function(module, exports, __webpack_require__) {
 
-__webpack_require__(/*! /var/www/html/gokigen-ch/portfolio/kusocolla-maker/dev2/resources/js/app.js */"./resources/js/app.js");
-module.exports = __webpack_require__(/*! /var/www/html/gokigen-ch/portfolio/kusocolla-maker/dev2/resources/sass/app.scss */"./resources/sass/app.scss");
+__webpack_require__(/*! /var/www/html/gokigen-ch/portfolio/kusocolla-maker/dev1/resources/js/app.js */"./resources/js/app.js");
+module.exports = __webpack_require__(/*! /var/www/html/gokigen-ch/portfolio/kusocolla-maker/dev1/resources/sass/app.scss */"./resources/sass/app.scss");
 
 
 /***/ })

--- a/resources/sass/kusocolla.scss
+++ b/resources/sass/kusocolla.scss
@@ -68,14 +68,14 @@
     .move01 {
         top: 0;
         left: 0;
-        animation: move01 2s 1;
+        animation: move01-01 2s 1;
     }
     .move02 {
         width: 240px;
         height: 240px;
-        animation: move02 5s 1;
+        animation: move01-02 5s 1;
     }
-    @keyframes move01 {
+    @keyframes move01-01 {
         0% {
             top: 220px;
             left: 200px;
@@ -95,7 +95,7 @@
         }
     }
 
-    @keyframes move02 {
+    @keyframes move01-02 {
         0% {
             -webkit-transform: rotate(0deg);
             transform: rotate(0deg);
@@ -124,7 +124,7 @@
     background: url(/images/kusocolla02/kusocolla02-01.jpg) no-repeat top;
     background-size: 100%;
     overflow: hidden;
-    animation: move01 4s infinite step-end;
+    animation: move02-01 4s infinite step-end;
 
     .kusocolla02__img-fixed {
         width: 100%;
@@ -176,7 +176,7 @@
         width: 12%;
         height: auto;
         opacity: 1;
-        animation: face01 4s infinite step-end;
+        animation: face02-01 4s infinite step-end;
     }
     //左から2番目
     .face-02 {
@@ -185,7 +185,7 @@
         width: 12%;
         height: auto;
         opacity: 1;
-        animation: face02 4s infinite step-end;
+        animation: face02-02 4s infinite step-end;
     }
     //左から3番目
     .face-03 {
@@ -194,7 +194,7 @@
         width: 12%;
         height: auto;
         opacity: 1;
-        animation: face03 4s infinite step-end;
+        animation: face02-03 4s infinite step-end;
     }
     //左から4番目
     .face-04 {
@@ -203,7 +203,7 @@
         width: 12%;
         height: auto;
         opacity: 1;
-        animation: face04 4s infinite step-end;
+        animation: face02-04 4s infinite step-end;
     }
 
     @keyframes heart {
@@ -254,7 +254,7 @@
         }
     }
 
-    @keyframes move01 {
+    @keyframes move02-01 {
         0% {
             background: url(/images/kusocolla02/kusocolla02-01.jpg) no-repeat top;
             background-size: 100%;
@@ -293,7 +293,7 @@
         }
     }
 
-    @keyframes face01 {
+    @keyframes face02-01 {
         0% {
             opacity: 0;
         }
@@ -326,7 +326,7 @@
             opacity: 0;
         }
     }
-    @keyframes face02 {
+    @keyframes face02-02 {
         0% {
             opacity: 0;
         }
@@ -359,7 +359,7 @@
             opacity: 0;
         }
     }
-    @keyframes face03 {
+    @keyframes face02-03 {
         0% {
             top: 6%;
             left: 65%;
@@ -394,7 +394,7 @@
             opacity: 1;
         }
     }
-    @keyframes face04 {
+    @keyframes face02-04 {
         0% {
             opacity: 0;
         }


### PR DESCRIPTION
- 原因
クソコラ１画面を表示したときに、最初だけクソコラ２のアニメーションが効いてしまっていた。
クソコラ１とクソコラ２の@keyframesの名前が被っていた。
@keyframesの名前（例：move01など）にはsassのネスト機能（名前空間？）が効かないらしい。

- 対策
@keyframesの名前をクソコラ１と２で分けた。
愚直に、move01-01とかmove02-01とかにした。
