### PR TITLE
fix: ロード画面によりクソコラ表示時のチラツキを無くす

### DIFF
--- a/app/Http/Controllers/ImageController.php
+++ b/app/Http/Controllers/ImageController.php
@@ -86,10 +86,9 @@ class ImageController extends Controller
      */
     public function show(Image $image, $kusocola)
     {
-        return view('image', 
+        return view('kusocolas.' . $kusocola, 
             [
-                'image' => $image,
-                'kusocola' => $kusocola
+                'image' => $image
             ]
         );
     }

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -12864,3 +12864,14 @@ label > input {
   }
 }
 
+#js-loading-wait {
+  width: 100%;
+  height: 100vh;
+  background-color: #D44071;
+  position: relative;
+}
+
+.js-loading-hidden {
+  display: none;
+}
+

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -37008,6 +37008,8 @@ __webpack_require__(/*! ./bootstrap */ "./resources/js/bootstrap.js");
 
 __webpack_require__(/*! ./updateImageDisplay */ "./resources/js/updateImageDisplay.js");
 
+__webpack_require__(/*! ./loading */ "./resources/js/loading.js");
+
 /***/ }),
 
 /***/ "./resources/js/bootstrap.js":
@@ -37055,6 +37057,31 @@ window.axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
 
 /***/ }),
 
+/***/ "./resources/js/loading.js":
+/*!*********************************!*\
+  !*** ./resources/js/loading.js ***!
+  \*********************************/
+/*! no static exports found */
+/***/ (function(module, exports) {
+
+// loadingのdivを取得
+var loading = document.getElementById('js-loading-wait'); // contentsのdivを取得
+
+var contents = document.getElementById('js-loading-contents');
+
+if (loading != null && contents != null) {
+  // 読み込みが完了したら
+  window.addEventListener('load', function () {
+    console.log('画面読み込み完了'); // loadingのdivを非表示に
+
+    loading.style.display = 'none'; // contentsのdivを表示
+
+    contents.classList.remove('js-loading-hidden');
+  });
+}
+
+/***/ }),
+
 /***/ "./resources/js/updateImageDisplay.js":
 /*!********************************************!*\
   !*** ./resources/js/updateImageDisplay.js ***!
@@ -37063,11 +37090,14 @@ window.axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
 /***/ (function(module, exports) {
 
 var form = document.querySelector('.js-image-form');
-var label = form.querySelector('label');
-var input = label.querySelector('input');
-var preview = form.querySelector('.js-preview');
-var button = form.querySelector('button');
-input.addEventListener('change', updateImageDisplay);
+
+if (form != null) {
+  var preview = form.querySelector('.js-preview');
+  var label = form.querySelector('label');
+  var input = label.querySelector('input');
+  var button = form.querySelector('button');
+  input.addEventListener('change', updateImageDisplay);
+}
 
 function updateImageDisplay() {
   // 前回アップロードした情報を削除

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,2 +1,3 @@
 require('./bootstrap');
 require('./updateImageDisplay')
+require('./loading')

--- a/resources/js/loading.js
+++ b/resources/js/loading.js
@@ -1,0 +1,15 @@
+// loadingのdivを取得
+let loading = document.getElementById('js-loading-wait');
+// contentsのdivを取得
+let contents = document.getElementById('js-loading-contents');
+
+if((loading != null) && (contents != null)){
+    // 読み込みが完了したら
+    window.addEventListener('load', function () {
+        console.log('画面読み込み完了');
+        // loadingのdivを非表示に
+        loading.style.display = 'none';
+        // contentsのdivを表示
+        contents.classList.remove('js-loading-hidden');
+    });
+}

--- a/resources/js/updateImageDisplay.js
+++ b/resources/js/updateImageDisplay.js
@@ -1,10 +1,11 @@
 var form = document.querySelector('.js-image-form')
-var label = form.querySelector('label')
-var input = label.querySelector('input')
-var preview = form.querySelector('.js-preview')
-var button = form.querySelector('button')
-
-input.addEventListener('change', updateImageDisplay);
+if(form != null){
+  var preview = form.querySelector('.js-preview')
+  var label = form.querySelector('label')
+  var input = label.querySelector('input')
+  var button = form.querySelector('button')
+  input.addEventListener('change', updateImageDisplay);
+}
 
 function updateImageDisplay() {
   // 前回アップロードした情報を削除

--- a/resources/sass/kusocolla.scss
+++ b/resources/sass/kusocolla.scss
@@ -428,3 +428,14 @@
         }
     }
 }
+
+#js-loading-wait{
+  width: 100%;
+  height: 100vh;
+  background-color:#D44071;
+  position: relative;
+}
+
+.js-loading-hidden{
+  display: none;
+}

--- a/resources/views/kusocolas/1.blade.php
+++ b/resources/views/kusocolas/1.blade.php
@@ -1,3 +1,16 @@
+@extends('layouts.kusocola')
+@section('ogp')
+<meta name="twitter:card" content="summary_large_image" />
+<!-- TODO: クソコラをTwitterシェアするときの文言、ハッシュタグ、アカウントをちゃんと考えたい #23 -->
+<meta name="twitter:site" content="@daisuke7924" />
+<meta name="twitter:creator" content="@daisuke7924" />
+<meta property="og:url" content="{{url()->current()}}" />
+<meta property="og:title" content="クソコラメーカー" />
+<meta property="og:description" content="さぁみんなで、ごきげんになろう！" />
+<!-- TODO: クソコラをSNSシェアするときのOGPを考え直したい #23 -->
+<meta property="og:image" content="{{url("/")}}/storage/image/{{$image->getFolder()}}/add.{{$image->getExtension()}}" />
+@endsection
+@section('kusocola')
     <div class="kusocolla">
         <img class="kusocolla__img-fixed" src="/images/kusocolla01/kusocolla01-01.jpg" alt="">
         <div class="kusocolla__face face-01">
@@ -31,3 +44,4 @@
             </div>
         </div>
     </div>
+@endsection

--- a/resources/views/kusocolas/2.blade.php
+++ b/resources/views/kusocolas/2.blade.php
@@ -1,3 +1,26 @@
+@extends('layouts.kusocola')
+@section('ogp')
+<meta name="twitter:card" content="summary_large_image" />
+<!-- TODO: クソコラをTwitterシェアするときの文言、ハッシュタグ、アカウントをちゃんと考えたい #23 -->
+<meta name="twitter:site" content="@daisuke7924" />
+<meta name="twitter:creator" content="@daisuke7924" />
+<meta property="og:url" content="{{url()->current()}}" />
+<meta property="og:title" content="クソコラメーカー" />
+<meta property="og:description" content="さぁみんなで、ごきげんになろう！" />
+<!-- TODO: クソコラをSNSシェアするときのOGPを考え直したい #23 -->
+<meta property="og:image" content="{{url("/")}}/storage/image/{{$image->getFolder()}}/add.{{$image->getExtension()}}" />
+@endsection
+@section('preload')
+<link rel="preload" href="{{url("/")}}/images/kusocolla02/kusocolla02-01.jpg" as="image">
+<link rel="preload" href="{{url("/")}}/images/kusocolla02/kusocolla02-02.jpg" as="image">
+<link rel="preload" href="{{url("/")}}/images/kusocolla02/kusocolla02-03.jpg" as="image">
+<link rel="preload" href="{{url("/")}}/images/kusocolla02/kusocolla02-04.jpg" as="image">
+<link rel="preload" href="{{url("/")}}/images/kusocolla02/kusocolla02-05.jpg" as="image">
+<link rel="preload" href="{{url("/")}}/images/kusocolla02/kusocolla02-06.jpg" as="image">
+<link rel="preload" href="{{url("/")}}/images/kusocolla02/kusocolla02-07.jpg" as="image">
+<link rel="preload" href="{{url("/")}}/images/kusocolla02/kusocolla02-08.jpg" as="image">
+@endsection
+@section('kusocola')
     <div class="kusocolla02">
         <div class="kusocolla02__img__inner">
             <div class="kusocolla02__face face-01">
@@ -24,3 +47,4 @@
         <p class="kusocolla02__text">何か言葉を入れたい</p>
         </div>
     </div>
+@endsection

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -21,6 +21,7 @@
     <!-- Styles -->
     <link href="{{ asset('css/app.css') }}" rel="stylesheet">
     @yield('ogp')
+    @yield('preload')
 </head>
 <body>
     <div id="app">

--- a/resources/views/layouts/kusocola.blade.php
+++ b/resources/views/layouts/kusocola.blade.php
@@ -1,18 +1,8 @@
 @extends('layouts.app')
-@section('ogp')
-<meta name="twitter:card" content="summary_large_image" />
-<!-- TODO: クソコラをTwitterシェアするときの文言、ハッシュタグ、アカウントをちゃんと考えたい #23 -->
-<meta name="twitter:site" content="@daisuke7924" />
-<meta name="twitter:creator" content="@daisuke7924" />
-<meta property="og:url" content="{{url()->current()}}" />
-<meta property="og:title" content="クソコラメーカー" />
-<meta property="og:description" content="さぁみんなで、ごきげんになろう！" />
-<!-- TODO: クソコラをSNSシェアするときのOGPを考え直したい #23 -->
-<meta property="og:image" content="{{url("/")}}/storage/image/{{$image->getFolder()}}/add.{{$image->getExtension()}}" />
-@endsection
-
 @section('content')
-@include('kusocolas.' . $kusocola)
+<div id="js-loading-wait"></div>
+<div class="js-loading-hidden" id="js-loading-contents">
+@yield('kusocola')
     <div class="container">
         <div class="row justify-content-center">
             <!-- TODO: #15: ちゃんとレスポンシブ対応する -->
@@ -44,5 +34,6 @@
             </div>
         </div>
     </div>
+</div>
 </div>
 @endsection


### PR DESCRIPTION
# 問題
ZOZOスーツクソコラを表示すると、画面がちらついてまぶしい(+_+)

# 原因
画像表示するその瞬間にサーバーから画像を取得→表示しているため。
画像をアニメーション表示するときに、各画像の初回表示時にチラツキが発生していた。2回目以降はキャッシュが効いてチラツキが消える。

# 対応内容
- 対応①：クソコラ画面表示するときにロード画面を表示する
  - ロード画面はloadイベント発火まで表示し続ける
    - load イベントは、ページ全体が、スタイルシートや画像などのすべての依存するリソースを含めて読み込まれたときに発生します。
  - ロード画面は、とりあえず画面全体をごきげんピンク一色にしてる

- 対応②：ロード画面中にクソコラに使う全ての画像を取得する仕組みを追加
  - 対応①のみだとZOZOスーツのチラツキが治らなかった
    -  animationで使うbackground-imageはloadイベント後に読み込んでいた・・・悲しい。
  - headerタグ内で`<link rel="preload" href="animationで使うbackground-imageのURL" as="image">`を書くことで、animationで使うbackground-imageをloadイベント前に読み込む
  - preloadする画像はクソコラ毎に指定できるようにした
     -  views/kusocolas/*.blade.phpの`@section('preload')`内に記載すること

# 注意事項
- 対応②の影響で、views/kusocolas/*.blade.phpの書き方が微妙に変わっちゃった・・・競合するかもごめん。
- image.blade.phpの名前をなんとなくkusocola.blade.phpに変えちゃった・・・